### PR TITLE
Change legacy string to multi-line string

### DIFF
--- a/vcl/src/FlixAccounting.dpr
+++ b/vcl/src/FlixAccounting.dpr
@@ -54,7 +54,15 @@ begin
   end
   else
   begin
-    MessageDlg('Cannot launch application. Please check that database configuration ' +
-     'exists in settings.ini.', mtError, [mbOK], 0);
+    MessageDlg(
+      '''
+      Cannot launch application. Please check
+      that database configuration
+      exists in settings.ini.
+      ''',
+     mtError,
+     [mbOK],
+     0
+     );
   end;
 end.


### PR DESCRIPTION
Change the legacy string (<D11) to a multi-line string that is supoorted beginning with D12.