### PR TITLE
More readable empty strings

### DIFF
--- a/bpl/src/UCustomer.pas
+++ b/bpl/src/UCustomer.pas
@@ -69,15 +69,15 @@ implementation
 
 constructor TCustomer.Create;
 begin
-  FName := '';
-  FContact := '';
-  FAddress := '';
-  FEmail := '';
+  FName := String.Empty;
+  FContact := String.Empty;
+  FAddress := String.Empty;
+  FEmail := String.Empty;
 end;
 
 function TCustomer.GetAddressExcel: String;
 begin
-  Result := Address.Replace(#13, '' );
+  Result := Address.Replace(#13, String.Empty );
 end;
 
 initialization

--- a/bpl/src/UCustomer.pas
+++ b/bpl/src/UCustomer.pas
@@ -64,6 +64,8 @@ type
   end;
 
 implementation
+const
+  cCarriageReturn = #13;
 
 { TCustomer }
 
@@ -77,7 +79,7 @@ end;
 
 function TCustomer.GetAddressExcel: String;
 begin
-  Result := Address.Replace(#13, String.Empty );
+  Result := Address.Replace(cCarriageReturn, String.Empty );
 end;
 
 initialization


### PR DESCRIPTION
With the String helper String.Empty this this is a more readable variant of a hard-coded empty string with `''`.